### PR TITLE
Disable hardcoded rate limits in scripts

### DIFF
--- a/testing/fake-llm-server/README.md
+++ b/testing/fake-llm-server/README.md
@@ -7,7 +7,6 @@ A simple server that mimics the OpenAI streaming chat completions API for testin
 - Implements a basic version of the OpenAI chat completions API
 - Supports both streaming and non-streaming responses
 - Always responds with "hello world" message
-- Simulates a 429 rate limit error when the last message is "[429]"
 - Configurable through environment variables
 
 ## Installation
@@ -83,29 +82,6 @@ For non-streaming requests, you'll get a standard JSON response:
 
 For streaming requests, you'll receive a series of server-sent events (SSE), each containing a chunk of the response.
 
-### Simulating Rate Limit Errors
-
-To test how your application handles rate limiting, send a message with content exactly equal to `[429]`:
-
-```json
-{
-  "messages": [{ "role": "user", "content": "[429]" }],
-  "model": "any-model"
-}
-```
-
-This will return a 429 status code with the following response:
-
-```json
-{
-  "error": {
-    "message": "Too many requests. Please try again later.",
-    "type": "rate_limit_error",
-    "param": null,
-    "code": "rate_limit_exceeded"
-  }
-}
-```
 
 ## Configuration
 

--- a/testing/fake-llm-server/chatCompletionHandler.ts
+++ b/testing/fake-llm-server/chatCompletionHandler.ts
@@ -10,18 +10,8 @@ export const createChatCompletionHandler =
     const { stream = false, messages = [] } = req.body;
     console.log("* Received messages", messages);
 
-    // Check if the last message contains "[429]" to simulate rate limiting
+    // Disabled rate limit simulation
     const lastMessage = messages[messages.length - 1];
-    if (lastMessage && lastMessage.content === "[429]") {
-      return res.status(429).json({
-        error: {
-          message: "Too many requests. Please try again later.",
-          type: "rate_limit_error",
-          param: null,
-          code: "rate_limit_exceeded",
-        },
-      });
-    }
 
     let messageContent = CANNED_MESSAGE;
 


### PR DESCRIPTION
Disable the simulated 429 rate limit in the fake LLM server to remove client-side rate limiting.

This change addresses the user's request to disable script-based rate limitations, specifically by removing the `[429]` message trigger that simulated a `rate_limit_exceeded` error in the local test server.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e532158-2f50-4bdb-a417-9b5ef77d0344">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e532158-2f50-4bdb-a417-9b5ef77d0344">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

