### PR TITLE
Update repo star links to fork

### DIFF
--- a/src/components/chat/PromoMessage.tsx
+++ b/src/components/chat/PromoMessage.tsx
@@ -192,7 +192,7 @@ export const GITHUB_TIP: MessageConfig = {
     {
       type: "link",
       content: "GitHub",
-      url: "https://github.com/dyad-sh/dyad",
+      url: "https://github.com/pesachnps/dyad-without-the-limits",
     },
   ],
 };


### PR DESCRIPTION
Update the "Star on GitHub" link to point to the user's fork.

---
<a href="https://cursor.com/background-agent?bcId=bc-a084f31b-2f22-4038-9dab-85e6647bca32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a084f31b-2f22-4038-9dab-85e6647bca32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

